### PR TITLE
Fix merge conflict markers in sprites.asm

### DIFF
--- a/gfx/sprites.asm
+++ b/gfx/sprites.asm
@@ -71,9 +71,7 @@ AgathaSprite::           INCBIN "gfx/sprites/agatha.2bpp"
 BrunoSprite::            INCBIN "gfx/sprites/bruno.2bpp"
 LoreleiSprite::          INCBIN "gfx/sprites/lorelei.2bpp"
 SeelSprite::             INCBIN "gfx/sprites/seel.2bpp"
-<<<<<<< ours
-=======
 
 SECTION "Pug Sprite", ROMX
->>>>>>> theirs
+
 PugSprite::              INCBIN "gfx/sprites/pug.2bpp"


### PR DESCRIPTION
## Summary
- remove leftover merge markers from `gfx/sprites.asm`

## Testing
- `grep -n "<<<<<<<" -R`

------
https://chatgpt.com/codex/tasks/task_e_6854d1b31b7c832cbafc65dd75198063